### PR TITLE
refactor: EFI & graphics をモジュール化

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2024-01-01"
+channel = "nightly"
 components = ["rustfmt", "rust-src"]
 targets = ["x86_64-unknown-linux-gnu", "x86_64-unknown-uefi"]
 profile = "default"

--- a/src/efi.rs
+++ b/src/efi.rs
@@ -1,0 +1,119 @@
+#![allow(dead_code)]
+//! UEFI 関連の FFI 構造体と GPU 初期化ラッパ。
+//! 
+//! - SystemTable から Graphics Output Protocol(GOP) を取得し、
+//!   フレームバッファを `graphics::FrameBuffer` として返すユーティリティを提供。
+//! - 低レベル構造体は public にしているため、`efi_main` のシグネチャにも再利用可能。
+
+use core::mem::{offset_of, size_of};
+use core::ptr::null_mut;
+use crate::graphics::FrameBuffer;
+
+pub type Result<T> = core::result::Result<T, &'static str>;
+
+pub type EfiVoid = u8;
+/// UEFI が渡すイメージハンドル型
+pub type EfiHandle = u64;
+
+#[repr(C)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct EfiGuid {
+    pub data0: u32,
+    pub data1: u16,
+    pub data2: u16,
+    pub data3: [u8; 8],
+}
+
+/// Graphics Output Protocol GUID
+pub const EFI_GRAPHICS_OUTPUT_PROTOCOL_GUID: EfiGuid = EfiGuid {
+    data0: 0x9042a9de,
+    data1: 0x23dc,
+    data2: 0x4a38,
+    data3: [0x96, 0xfb, 0x7a, 0xde, 0xd0, 0x80, 0x51, 0x6a],
+};
+
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+#[must_use]
+#[repr(u64)]
+pub enum EfiStatus {
+    Success = 0,
+}
+
+#[repr(C)]
+pub struct EfiBootServicesTable {
+    _reserved0: [u64; 40],
+    pub locate_protocol: extern "win64" fn(
+        protocol: *const EfiGuid,
+        registration: *const EfiVoid,
+        interface: *mut *mut EfiVoid,
+    ) -> EfiStatus,
+}
+const _: () = assert!(offset_of!(EfiBootServicesTable, locate_protocol) == 320);
+
+#[repr(C)]
+pub struct EfiSystemTable {
+    _reserved0: [u64; 12],
+    pub boot_services: &'static EfiBootServicesTable,
+}
+const _: () = assert!(offset_of!(EfiSystemTable, boot_services) == 96);
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct EfiGraphicsOutputProtocolPixelInfo {
+    version: u32,
+    pub horizontal_resolution: u32,
+    pub vertical_resolution: u32,
+    _padding0: [u32; 5],
+    pub pixels_per_scan_line: u32,
+}
+const _: () = assert!(size_of::<EfiGraphicsOutputProtocolPixelInfo>() == 36);
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct EfiGraphicsOutputProtocolMode<'a> {
+    pub max_mode: u32,
+    pub mode: u32,
+    pub info: &'a EfiGraphicsOutputProtocolPixelInfo,
+    pub size_of_info: u64,
+    pub frame_buffer_base: usize,
+    pub frame_buffer_size: usize,
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct EfiGraphicsOutputProtocol<'a> {
+    reserved: [u64; 3],
+    pub mode: &'a EfiGraphicsOutputProtocolMode<'a>,
+}
+
+/// `SystemTable` から GOP を検索し、`FrameBuffer` を生成して返す
+pub fn framebuffer<'a>(system_table: &'a EfiSystemTable) -> Result<FrameBuffer<'a>> {
+    // GOP へのポインタ
+    let mut gop_ptr = null_mut::<EfiGraphicsOutputProtocol>();
+    let status = (system_table.boot_services.locate_protocol)(
+        &EFI_GRAPHICS_OUTPUT_PROTOCOL_GUID,
+        null_mut::<EfiVoid>(),
+        &mut gop_ptr as *mut *mut EfiGraphicsOutputProtocol as *mut *mut EfiVoid,
+    );
+
+    if status != EfiStatus::Success {
+        return Err("Failed to locate graphics output protocol");
+    }
+    // Safety: UEFI が有効な GOP を返したと仮定
+    let gop = unsafe { &*gop_ptr };
+
+    let vram_addr = gop.mode.frame_buffer_base;
+    let vram_byte_size = gop.mode.frame_buffer_size;
+    let width = gop.mode.info.horizontal_resolution as usize;
+    let height = gop.mode.info.vertical_resolution as usize;
+
+    // Safety: フレームバッファ領域は UEFI により確保済みで、32bit ピクセルが連続して並ぶ
+    let vram_slice = unsafe {
+        core::slice::from_raw_parts_mut(
+            vram_addr as *mut u32,
+            vram_byte_size / size_of::<u32>(),
+        )
+    };
+
+    Ok(FrameBuffer::new(vram_slice, width, height))
+} 

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: MIT
+#![allow(dead_code)]
+//! `graphics` モジュール
+//! 
+//! - ピクセル・矩形・テキスト描画などの基本 API を提供します。
+//! - UEFI のフレームバッファへのアクセスを想定しており 32-bit BGRX/RGBX 形式を扱います。
+
+use core::cmp::{max, min};
+
+/// 24bit カラー定数 (0xRRGGBB)
+/// 必要に応じて追加してください。
+pub const COLOR_BLACK: u32 = 0x000000;
+pub const COLOR_WHITE: u32 = 0xFFFFFF;
+pub const COLOR_BLUE: u32 = 0x0000FF;
+pub const COLOR_RED: u32 = 0xFF0000;
+pub const COLOR_GREEN: u32 = 0x00FF00;
+
+/// フレームバッファハンドル
+pub struct FrameBuffer<'a> {
+    /// フレームバッファ(仮想アドレス) 32bit 色値リニア配列
+    vram: &'a mut [u32],
+    pub width: usize,
+    pub height: usize,
+}
+
+impl<'a> FrameBuffer<'a> {
+    /// 新しい `FrameBuffer` を生成
+    pub fn new(vram: &'a mut [u32], width: usize, height: usize) -> Self {
+        Self { vram, width, height }
+    }
+
+    /// ピクセルを描画 (境界チェック付き)
+    pub fn draw_pixel(&mut self, x: usize, y: usize, color: u32) {
+        if x < self.width && y < self.height {
+            let idx = y * self.width + x;
+            self.vram[idx] = color;
+        }
+    }
+
+    /// 画面全体を単色で塗りつぶし
+    pub fn clear(&mut self, color: u32) {
+        for px in self.vram.iter_mut() {
+            *px = color;
+        }
+    }
+
+    /// 矩形描画 (塗りつぶし)
+    pub fn fill_rect(&mut self, x: usize, y: usize, w: usize, h: usize, color: u32) {
+        let x_end = min(x.saturating_add(w), self.width);
+        let y_end = min(y.saturating_add(h), self.height);
+
+        for yy in y..y_end {
+            let row_start = yy * self.width;
+            for xx in x..x_end {
+                self.vram[row_start + xx] = color;
+            }
+        }
+    }
+
+    /// 矩形の枠線のみ描画
+    pub fn stroke_rect(&mut self, x: usize, y: usize, w: usize, h: usize, color: u32) {
+        if w == 0 || h == 0 {
+            return;
+        }
+        // 上下ライン
+        for xx in x..min(x + w, self.width) {
+            self.draw_pixel(xx, y, color);
+            self.draw_pixel(xx, y + h.saturating_sub(1), color);
+        }
+        // 左右ライン
+        for yy in y..min(y + h, self.height) {
+            self.draw_pixel(x, yy, color);
+            self.draw_pixel(x + w.saturating_sub(1), yy, color);
+        }
+    }
+
+    /// 簡易ライン描画 (Bresenham)
+    pub fn draw_line(&mut self, mut x0: isize, mut y0: isize, x1: isize, y1: isize, color: u32) {
+        let dx = (x1 - x0).abs();
+        let sx = if x0 < x1 { 1 } else { -1 };
+        let dy = -(y1 - y0).abs();
+        let sy = if y0 < y1 { 1 } else { -1 };
+        let mut err = dx + dy;
+
+        let width_i = self.width as isize;
+        let height_i = self.height as isize;
+
+        loop {
+            if x0 >= 0 && y0 >= 0 && x0 < width_i && y0 < height_i {
+                self.draw_pixel(x0 as usize, y0 as usize, color);
+            }
+            if x0 == x1 && y0 == y1 {
+                break;
+            }
+            let e2 = err * 2;
+            if e2 >= dy {
+                err += dy;
+                x0 += sx;
+            }
+            if e2 <= dx {
+                err += dx;
+                y0 += sy;
+            }
+        }
+    }
+
+    /// 円の塗りつぶし描画 (Midpoint circle algorithm)
+    pub fn fill_circle(&mut self, cx: isize, cy: isize, radius: isize, color: u32) {
+        if radius <= 0 {
+            return;
+        }
+        let mut x = radius;
+        let mut y = 0;
+        let mut err = 0;
+
+        while x >= y {
+            self.draw_hline_span(cx, cy, x, y, color);
+            y += 1;
+            if err <= 0 {
+                err += 2 * y + 1;
+            } else {
+                x -= 1;
+                err -= 2 * x + 1;
+            }
+        }
+    }
+
+    /// 文字描画 (8x8 フォント)
+    pub fn draw_char(&mut self, x: usize, y: usize, ch: char, color: u32) {
+        if let Some(bitmap) = font_for(ch) {
+            for (dy, line) in bitmap.iter().enumerate() {
+                for dx in 0..8 {
+                    if (line >> (7 - dx)) & 0x01 != 0 {
+                        self.draw_pixel(x + dx, y + dy, color);
+                    }
+                }
+            }
+        }
+    }
+
+    /// テキスト描画 (横方向に等幅 8px、1 文字間 2px)
+    pub fn draw_text(&mut self, mut x: usize, y: usize, text: &str, color: u32) {
+        for ch in text.chars() {
+            self.draw_char(x, y, ch, color);
+            x += 8 + 2; // 文字幅 + スペース
+        }
+    }
+
+    /// Midpoint circle 用の水平スパン描画
+    fn draw_hline_span(&mut self, cx: isize, cy: isize, x: isize, y: isize, color: u32) {
+        let (cx, cy) = (cx as isize, cy as isize);
+        let width = self.width as isize;
+        let height = self.height as isize;
+
+        let pairs = [
+            (cx - x, cx + x, cy + y), // 下側
+            (cx - x, cx + x, cy - y), // 上側
+            (cx - y, cx + y, cy + x), // 右側
+            (cx - y, cx + y, cy - x), // 左側
+        ];
+
+        for &(x_start, x_end, yy) in &pairs {
+            if yy < 0 || yy >= height {
+                continue;
+            }
+            let xs = max(x_start, 0);
+            let xe = min(x_end, width - 1);
+            let row = yy as usize * self.width;
+            for xx in xs..=xe {
+                self.vram[row + xx as usize] = color;
+            }
+        }
+    }
+}
+
+// ======================= フォントデータ ===============================
+// 8x8 ビットマップフォント (必要な分だけ収録)
+// ビット列は左から MSB (bit7) が画面左側に対応。
+
+const FONT_SPACE: [u8; 8] = [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+const FONT_F: [u8; 8] = [0xFF, 0x80, 0x80, 0xF0, 0x80, 0x80, 0x80, 0x80];
+const FONT_E: [u8; 8] = [0xFF, 0x80, 0x80, 0xF0, 0x80, 0x80, 0x80, 0xFF];
+const FONT_R: [u8; 8] = [0xF0, 0x88, 0x88, 0xF0, 0xA0, 0x90, 0x88, 0x84];
+const FONT_O: [u8; 8] = [0x78, 0x84, 0x84, 0x84, 0x84, 0x84, 0x84, 0x78];
+const FONT_S: [u8; 8] = [0x78, 0x84, 0x80, 0x78, 0x04, 0x04, 0x84, 0x78];
+
+/// 対応している文字のフォントを取得
+fn font_for(ch: char) -> Option<&'static [u8; 8]> {
+    match ch {
+        ' ' => Some(&FONT_SPACE),
+        'F' => Some(&FONT_F),
+        'E' => Some(&FONT_E),
+        'R' => Some(&FONT_R),
+        'O' => Some(&FONT_O),
+        'S' => Some(&FONT_S),
+        _ => None, // 未サポート文字
+    }
+} 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,173 +2,45 @@
 #![no_main]
 #![feature(offset_of)]
 
-use core::mem::offset_of;
-use core::mem::size_of;
 use core::panic::PanicInfo;
-use core::ptr::null_mut;
-use core::slice;
 
-type EfiVoid = u8;
-type EfiHandle = u64;
-type Result<T> = core::result::Result<T, &'static str>;
+mod graphics;
+use graphics::{FrameBuffer, COLOR_BLUE, COLOR_WHITE, COLOR_RED, COLOR_GREEN};
 
-#[repr(C)]
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-struct EfiGuid {
-    pub data0: u32,
-    pub data1: u16,
-    pub data2: u16,
-    pub data3: [u8; 8],
-}
+mod efi;
+use efi::{EfiHandle, EfiSystemTable, framebuffer};
 
-const EFI_GRAPHICS_OUTPUT_PROTOCOL_GUID: EfiGuid = EfiGuid {
-    data0: 0x9042a9de,
-    data1: 0x23dc,
-    data2: 0x4a38,
-    data3: [0x96, 0xfb, 0x7a, 0xde, 0xd0, 0x80, 0x51, 0x6a],
-};
+// ------------------------------------------------------------
+// 簡易 UI モジュール（暫定）
+mod ui {
+    use crate::graphics::{FrameBuffer, COLOR_BLUE, COLOR_WHITE, COLOR_RED, COLOR_GREEN};
 
-#[derive(Debug, PartialEq, Eq, Copy, Clone)]
-#[must_use]
-#[repr(u64)]
-enum EfiStatus {
-    Success = 0,
-}
+    /// ホーム画面を描画
+    pub fn home(fb: &mut FrameBuffer) {
+        // 背景
+        fb.clear(COLOR_BLUE);
 
-#[repr(C)]
-struct EfiBootServicesTable {
-    _reserved0: [u64; 40],
-    locate_protocol: extern "win64" fn(
-        protocol: *const EfiGuid,
-        registration: *const EfiVoid,
-        interface: *mut *mut EfiVoid,
-    ) -> EfiStatus,
-}
-const _: () = assert!(offset_of!(EfiBootServicesTable, locate_protocol) == 320);
+        // テキスト
+        let label = "FERR OS";
+        let text_width = label.len() * 8 + (label.len() - 1) * 2;
+        let x = (fb.width - text_width) / 2;
+        let y = fb.height / 2 - 4;
+        fb.draw_text(x, y, label, COLOR_WHITE);
 
-#[repr(C)]
-struct EfiSystemTable {
-    _reserved0: [u64; 12],
-    pub boot_services: &'static EfiBootServicesTable,
-}
-const _: () = assert!(offset_of!(EfiSystemTable, boot_services) == 96);
-
-#[repr(C)]
-#[derive(Debug)]
-struct EfiGraphicsOutputProtocolPixelInfo {
-    version: u32,
-    pub horizontal_resolution: u32,
-    pub vertical_resolution: u32,
-    _padding0: [u32; 5],
-    pub pixels_per_scan_line: u32,
-}
-const _: () = assert!(size_of::<EfiGraphicsOutputProtocolPixelInfo>() == 36);
-
-#[repr(C)]
-#[derive(Debug)]
-struct EfiGraphicsOutputProtocolMode<'a> {
-    pub max_mode: u32,
-    pub mode: u32,
-    pub info: &'a EfiGraphicsOutputProtocolPixelInfo,
-    pub size_of_info: u64,
-    pub frame_buffer_base: usize,
-    pub frame_buffer_size: usize,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-struct EfiGraphicsOutputProtocol<'a> {
-    reserved: [u64; 3],
-    pub mode: &'a EfiGraphicsOutputProtocolMode<'a>,
-}
-fn locate_graphic_protocol<'a>(
-    efi_system_table: &EfiSystemTable,
-) -> Result<&'a EfiGraphicsOutputProtocol<'a>> {
-    let mut graphic_output_protocol = null_mut::<EfiGraphicsOutputProtocol>();
-    let status = (efi_system_table.boot_services.locate_protocol)(
-        &EFI_GRAPHICS_OUTPUT_PROTOCOL_GUID,
-        null_mut::<EfiVoid>(),
-        &mut graphic_output_protocol as *mut *mut EfiGraphicsOutputProtocol
-            as *mut *mut EfiVoid,
-    );
-    if status != EfiStatus::Success {
-        return Err("Failed to locate graphics output protocol");
-    }
-    Ok(unsafe { &*graphic_output_protocol })
-}
-
-// 色定数
-const COLOR_BLUE: u32 = 0x0000FF;
-const COLOR_WHITE: u32 = 0xFFFFFF;
-
-// 簡易的なピクセル描画関数
-fn draw_pixel(vram: &mut [u32], x: usize, y: usize, width: usize, color: u32) {
-    if x < width {
-        vram[y * width + x] = color;
+        // 図形例 (円・矩形など)
+        fb.fill_rect(20, 20, 80, 50, COLOR_RED);
+        fb.stroke_rect(fb.width - 140, 30, 120, 80, COLOR_GREEN);
+        fb.fill_circle((fb.width / 2) as isize, (fb.height * 3 / 4) as isize, 40, COLOR_GREEN);
     }
 }
-
-// 文字描画用の簡易フォントデータ（8x8ピクセル）
-// 'F', 'E', 'R', ' ', 'O', 'S' のビットマップ
-const FONT_F: [u8; 8] = [0xFF, 0x80, 0x80, 0xF0, 0x80, 0x80, 0x80, 0x80];
-const FONT_E: [u8; 8] = [0xFF, 0x80, 0x80, 0xF0, 0x80, 0x80, 0x80, 0xFF];
-const FONT_R: [u8; 8] = [0xF0, 0x88, 0x88, 0xF0, 0xA0, 0x90, 0x88, 0x84];
-const FONT_SPACE: [u8; 8] = [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
-const FONT_O: [u8; 8] = [0x78, 0x84, 0x84, 0x84, 0x84, 0x84, 0x84, 0x78];
-const FONT_S: [u8; 8] = [0x78, 0x84, 0x80, 0x78, 0x04, 0x04, 0x84, 0x78];
-
-// 文字描画関数
-fn draw_char(vram: &mut [u32], x: usize, y: usize, width: usize, font: &[u8; 8], color: u32) {
-    for dy in 0..8 {
-        let line = font[dy];
-        for dx in 0..8 {
-            if (line >> (7 - dx)) & 0x01 != 0 {
-                draw_pixel(vram, x + dx, y + dy, width, color);
-            }
-        }
-    }
-}
-
-// テキスト描画関数
-fn draw_text(vram: &mut [u32], x: usize, y: usize, width: usize) {
-    // "FERR OS" を描画
-    draw_char(vram, x, y, width, &FONT_F, COLOR_WHITE);
-    draw_char(vram, x + 10, y, width, &FONT_E, COLOR_WHITE);
-    draw_char(vram, x + 20, y, width, &FONT_R, COLOR_WHITE);
-    draw_char(vram, x + 30, y, width, &FONT_R, COLOR_WHITE);
-    draw_char(vram, x + 40, y, width, &FONT_SPACE, COLOR_WHITE);
-    draw_char(vram, x + 50, y, width, &FONT_O, COLOR_WHITE);
-    draw_char(vram, x + 60, y, width, &FONT_S, COLOR_WHITE);
-}
+// ------------------------------------------------------------
 
 #[no_mangle]
-fn efi_main(_image_handle: EfiHandle, efi_system_table: &EfiSystemTable) {
-    let efi_graphics_output_protocol =
-        locate_graphic_protocol(efi_system_table).unwrap();
-    
-    // フレームバッファ情報を取得
-    let vram_addr = efi_graphics_output_protocol.mode.frame_buffer_base;
-    let vram_byte_size = efi_graphics_output_protocol.mode.frame_buffer_size;
-    let width = efi_graphics_output_protocol.mode.info.horizontal_resolution as usize;
-    let height = efi_graphics_output_protocol.mode.info.vertical_resolution as usize;
-    
-    // フレームバッファへのアクセス
-    let vram = unsafe {
-        slice::from_raw_parts_mut(
-            vram_addr as *mut u32,
-            vram_byte_size / size_of::<u32>(),
-        )
-    };
-    
-    // 画面を青色で塗りつぶす
-    for e in vram.iter_mut() {
-        *e = COLOR_BLUE;
-    }
-    
-    // 画面中央にテキストを描画
-    let text_x = width / 2 - 30;
-    let text_y = height / 2 - 4;
-    draw_text(vram, text_x, text_y, width);
+fn efi_main(_image_handle: EfiHandle, system_table: &EfiSystemTable) {
+    let mut fb = framebuffer(system_table).expect("GOP unavailable");
+
+    // ホーム画面を描画
+    ui::home(&mut fb);
     
     loop {}
 }


### PR DESCRIPTION
## 目的
- main.rs をシンプルに保ち、描画処理と UEFI FFI を分離する

## 変更点
- src/efi.rs: UEFI 関連構造体と frame_buffer 取得ヘルパ追加
- src/graphics.rs: 描画 API を実装
- src/main.rs: 初期化＋UI 呼び出しのみ
- rust-toolchain.toml: nightly に更新

## 動作確認
- ``` cargo check --target x86_64-unknown-uefi ```が通ることを確認済み
- QEMU 起動でホーム画面・図形表示を確認済み。