### PR TITLE
feat: ExitBootServices 実装 - UEFI 依存の切り離し

### DIFF
--- a/src/efi.rs
+++ b/src/efi.rs
@@ -51,7 +51,9 @@ pub struct EfiBootServicesTable {
     ) -> EfiStatus,
     _reserved1: [u64; 21],
     pub exit_boot_services: extern "win64" fn(image_handle: EfiHandle, map_key: usize) -> EfiStatus,
-    _reserved2: [u64; 10],
+    pub get_next_monotonic_count: extern "win64" fn(count: *mut u64) -> EfiStatus,
+    pub stall: extern "win64" fn(microseconds: usize) -> EfiStatus,
+    _reserved2: [u64; 8],
     pub locate_protocol: extern "win64" fn(
         protocol: *const EfiGuid,
         registration: *const EfiVoid,

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,13 +3,14 @@
 #![feature(offset_of)]
 
 use core::panic::PanicInfo;
+use core::str;
 
 mod font;
 mod graphics;
 use graphics::{FrameBuffer, COLOR_BLUE, COLOR_WHITE, COLOR_RED, COLOR_GREEN};
 
 mod efi;
-use efi::{EfiHandle, EfiSystemTable, framebuffer};
+use efi::{EfiHandle, EfiSystemTable, framebuffer, MemoryMapHolder, EfiStatus};
 
 // ------------------------------------------------------------
 // 簡易 UI モジュール（暫定）
@@ -37,13 +38,65 @@ mod ui {
 // ------------------------------------------------------------
 
 #[no_mangle]
-fn efi_main(_image_handle: EfiHandle, system_table: &EfiSystemTable) {
+fn efi_main(image_handle: EfiHandle, system_table: &EfiSystemTable) {
     let mut fb = framebuffer(system_table).expect("GOP unavailable");
 
     // ホーム画面を描画
     ui::home(&mut fb);
     
+    // BootServices ポインタ (ExitBootServices 前)
+    let bs_before = system_table.boot_services as *const _ as usize;
+
+    // BootServices との決別: ExitBootServices を呼び出す
+    let mut mmap = MemoryMapHolder::new();
+    exit_from_efi_boot_services(image_handle, system_table, &mut mmap);
+
+    // BootServices ポインタ (ExitBootServices 後)
+    let bs_after = system_table.boot_services as *const _ as usize;
+
+    // 表示（高さを事前にコピーして借用競合を避ける）
+    let h = fb.height;
+    draw_hex_message(&mut fb, 10, h - 40, "BS before=0x", bs_before);
+    draw_hex_message(&mut fb, 10, h - 20, "BS after =0x", bs_after);
+
     loop {}
+}
+
+/// ExitBootServices を安全に呼び出すヘルパ
+fn exit_from_efi_boot_services(
+    image_handle: EfiHandle,
+    system_table: &EfiSystemTable,
+    map_holder: &mut MemoryMapHolder,
+) {
+    loop {
+        let st = system_table.boot_services;
+        let status = st.call_get_memory_map(map_holder);
+        assert_eq!(status, EfiStatus::Success);
+
+        let status = (st.exit_boot_services)(image_handle, map_holder.map_key);
+        if status == EfiStatus::Success {
+            break;
+        }
+    }
+}
+
+/// `label` + 16進表記で数値を描画
+fn draw_hex_message(fb: &mut FrameBuffer, x: usize, y: usize, label: &str, value: usize) {
+    fb.draw_text(x, y, label, COLOR_WHITE);
+    // 16 桁の 0 埋め 16 進文字列を生成
+    let mut buf = [0u8; 18]; // "0x" + 16桁
+    buf[0] = b'0';
+    buf[1] = b'x';
+    for i in 0..16 {
+        let nibble = ((value >> ((15 - i) * 4)) & 0xF) as u8;
+        buf[2 + i] = match nibble {
+            0..=9 => b'0' + nibble,
+            _ => b'A' + (nibble - 10),
+        };
+    }
+    if let Ok(hex_str) = str::from_utf8(&buf) {
+        fb.draw_text(x + label.len() * 10, y, hex_str, COLOR_WHITE);
+    }
 }
 
 #[panic_handler]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,11 +3,10 @@
 #![feature(offset_of)]
 
 use core::panic::PanicInfo;
-use core::str;
 
 mod font;
 mod graphics;
-use graphics::{FrameBuffer, COLOR_BLUE, COLOR_WHITE, COLOR_RED, COLOR_GREEN};
+use graphics::{FrameBuffer, COLOR_WHITE, COLOR_RED, COLOR_GREEN};
 
 mod efi;
 use efi::{EfiHandle, EfiSystemTable, framebuffer, MemoryMapHolder, EfiStatus};
@@ -44,20 +43,23 @@ fn efi_main(image_handle: EfiHandle, system_table: &EfiSystemTable) {
     // ホーム画面を描画
     ui::home(&mut fb);
     
+    // 1 秒待機（1,000,000 マイクロ秒）
+    let _ = (system_table.boot_services.stall)(1_000_000usize);
+
     // BootServices ポインタ (ExitBootServices 前)
-    let bs_before = system_table.boot_services as *const _ as usize;
+    let _bs_before = system_table.boot_services as *const _ as usize;
 
     // BootServices との決別: ExitBootServices を呼び出す
     let mut mmap = MemoryMapHolder::new();
     exit_from_efi_boot_services(image_handle, system_table, &mut mmap);
 
-    // BootServices ポインタ (ExitBootServices 後)
-    let bs_after = system_table.boot_services as *const _ as usize;
-
-    // 表示（高さを事前にコピーして借用競合を避ける）
-    let h = fb.height;
-    draw_hex_message(&mut fb, 10, h - 40, "BS before=0x", bs_before);
-    draw_hex_message(&mut fb, 10, h - 20, "BS after =0x", bs_after);
+    // 以降は Non-UEFI 世界。画面をクリアしてメッセージ表示
+    fb.clear(COLOR_RED);
+    let label = "Hello, NonUEFI!";
+    let text_width = label.len() * 8 + (label.len() - 1) * 2;
+    let x = (fb.width - text_width) / 2;
+    let y = fb.height / 2 - 4;
+    fb.draw_text(x, y, label, COLOR_WHITE);
 
     loop {}
 }
@@ -77,25 +79,6 @@ fn exit_from_efi_boot_services(
         if status == EfiStatus::Success {
             break;
         }
-    }
-}
-
-/// `label` + 16進表記で数値を描画
-fn draw_hex_message(fb: &mut FrameBuffer, x: usize, y: usize, label: &str, value: usize) {
-    fb.draw_text(x, y, label, COLOR_WHITE);
-    // 16 桁の 0 埋め 16 進文字列を生成
-    let mut buf = [0u8; 18]; // "0x" + 16桁
-    buf[0] = b'0';
-    buf[1] = b'x';
-    for i in 0..16 {
-        let nibble = ((value >> ((15 - i) * 4)) & 0xF) as u8;
-        buf[2 + i] = match nibble {
-            0..=9 => b'0' + nibble,
-            _ => b'A' + (nibble - 10),
-        };
-    }
-    if let Ok(hex_str) = str::from_utf8(&buf) {
-        fb.draw_text(x + label.len() * 10, y, hex_str, COLOR_WHITE);
     }
 }
 


### PR DESCRIPTION
## 概要

Boot Services を切って、フレームバッファだけ握ったまま Non-UEFI に突入。

## 変更

- **src/main.rs**
  - `exit_from_efi_boot_services` ヘルパ追加
  - 切り離し後に画面を赤で塗って "Hello, NonUEFI!" を表示
- **src/efi.rs**
  - `MemoryMapHolder` と `EfiBootServicesTable::call_get_memory_map` を追加
  - GOP からフレームバッファ取得するユーティリティ `framebuffer` を実装
- **src/graphics.rs**
  - 矩形 / 円 / テキスト描画 API を整備
- **README.md**
  - 後で置く `docs/` へのリンクを追記

## 動作チェック

1. `cargo run` でビルド (target: `x86_64-unknown-uefi`)
2. `bash scripts/launch_qemu.sh target/x86_64-unknown-uefi/debug/ferr_os.efi`
3. 画面が 青 → 赤 に切り替わるのを確認

## 今後やること

- メモリマップ解析 → ページテーブル作り直し
- GDT/TSS / IDT 準備
- 物理メモリ & ヒープアロケータ
- 割り込み & タイマ